### PR TITLE
Add a node command for requesting an update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=5ee2b27#5ee2b274cb6a76ffe3e505f175c99ce100248ec6"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=b2a2032#b2a20327b29dcbe387b6c944df32e6f34bd952a1"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "5ee2b27"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "b2a2032"}
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }
 tonic = {version = "0.6", features = ["compression"]}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,16 @@ pub struct NodeOpts {
 pub enum NodeCommand {
     #[structopt(name = "state")]
     State(StateOpts),
+
+    #[structopt(name = "update")]
+    Update(UpdateOpts),
 }
 
 #[derive(StructOpt, Debug)]
 pub struct StateOpts {}
+
+#[derive(StructOpt, Debug)]
+pub struct UpdateOpts {
+    #[structopt(long = "base-url")]
+    pub base_url: String,
+}

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,11 +1,14 @@
-use crate::cli::{NodeCommand, NodeOpts};
+use crate::cli::{NodeCommand, NodeOpts, UpdateOpts};
 use peridio_sdk::node_client::NodeClient;
-use peridio_sdk::NodeStateRequest;
+use peridio_sdk::{NodeStateRequest, NodeUpdateRequest};
 
 pub async fn handle_command(opts: &NodeOpts) {
     match &opts.node_command {
         NodeCommand::State(_cfg) => {
             get_state(opts).await;
+        }
+        NodeCommand::Update(cfg) => {
+            update(opts, cfg).await;
         }
     }
 }
@@ -27,6 +30,29 @@ async fn get_state(opts: &NodeOpts) {
 
     match client.state(request).await {
         Ok(response) => println!("{}", response.into_inner()),
+        Err(e) => println!("{}", e),
+    }
+}
+
+async fn update(opts: &NodeOpts, update_opts: &UpdateOpts) {
+    let channel =
+        match peridio_sdk::channel(opts.socket_path.clone(), opts.socket_addr, opts.socket_port)
+            .await
+        {
+            Err(e) => {
+                println!("Error connecting to node\n{}", e);
+                return;
+            }
+            Ok(channel) => channel,
+        };
+
+    let mut client = NodeClient::new(channel);
+    let request = tonic::Request::new(NodeUpdateRequest {
+        base_url: update_opts.base_url.clone(),
+    });
+
+    match client.update(request).await {
+        Ok(response) => println!("{:?}", response.into_inner()),
         Err(e) => println!("{}", e),
     }
 }


### PR DESCRIPTION
Adds the following node command for requesting a node to update using the nodes gRPC control socket.

`peridio-cli node --socket-path /tmp/peridio-agent.sock update --base-url http://127.0.0.1:8080/`