### PR TITLE
PRO-237: Add `elements create` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +614,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,8 +692,9 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=d8f298b#d8f298baf41a23765c042c908f58319e7211d131"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=f133208#f133208b4a4b9f9e350debeb1488668c9459d6af"
 dependencies = [
+ "chrono",
  "prost",
  "prost-build",
  "reqwest",
@@ -1156,6 +1190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "d8f298b"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "f133208"}
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -1,0 +1,42 @@
+use super::Command;
+use peridio_sdk::{
+    api::{element, Error},
+    Api,
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum ElementCommand {
+    /// Create an element
+    Create(CreateCommand),
+}
+
+impl Command<ElementCommand> {
+    pub async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+
+        match &self.inner {
+            ElementCommand::Create(cmd) => cmd.run(api).await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    /// An element name
+    #[structopt(long)]
+    name: String,
+}
+
+impl CreateCommand {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let element = element::ElementChangeset {
+            name: self.name.clone(),
+        };
+
+        let element = api.elements().create(element).await?;
+        println!("{:?}", element);
+
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+mod element;
 mod identity;
 
 use std::ops::Deref;
@@ -29,12 +30,16 @@ impl<T: StructOpt> Deref for Command<T> {
 pub enum ApiCommand {
     /// Retrieve identity
     Identity(Command<identity::IdentityCommand>),
+
+    /// Operate on elements
+    Elements(Command<element::ElementCommand>),
 }
 
 impl ApiCommand {
     pub(crate) async fn run(self) -> Result<(), crate::Error> {
         match self {
             ApiCommand::Identity(cmd) => identity::run(cmd).await.context(crate::ApiSnafu)?,
+            ApiCommand::Elements(cmd) => cmd.run().await.context(crate::ApiSnafu)?,
         };
 
         Ok(())


### PR DESCRIPTION
**Why**
We would like to be able to create an element via our cli tooling.

**How**
- Add `elements create` cli commands
- Integrate `peridio_sdk::elements::create` api lib call