### PR TITLE
PRO-238: Add `elements get $id` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=871ce54#871ce54a57b21dd9d1765a95f22493affbe98a22"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=9f27eeb#9f27eeb97a69eb816f3e89cd84e02cf3d1f57d8b"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "871ce54"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "9f27eeb"}
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -15,6 +15,9 @@ pub enum ElementCommand {
 
     /// List elements
     List(ListCommand),
+
+    /// Get an element
+    Get(GetCommand),
 }
 
 impl Command<ElementCommand> {
@@ -25,6 +28,7 @@ impl Command<ElementCommand> {
             ElementCommand::Create(cmd) => cmd.run(api).await,
             ElementCommand::Update(cmd) => cmd.run(api).await,
             ElementCommand::List(cmd) => cmd.run(api).await,
+            ElementCommand::Get(cmd) => cmd.run(api).await,
         }
     }
 }
@@ -80,6 +84,20 @@ impl ListCommand {
     async fn run(&self, api: Api) -> Result<(), Error> {
         let elements = api.elements().list().await?;
         println!("{:?}", elements);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    id: String,
+}
+
+impl GetCommand {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let element = api.element(&self.id).get().await?;
+        println!("{:?}", element);
 
         Ok(())
     }


### PR DESCRIPTION
**Why**
We would like to be able to fetch an element via our cli tooling.

**How**
- Add `elements get` cli commands
- Integrate `peridio_sdk::elements::get` api lib call

