### PR TITLE
PRO-239: Add `elements list` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=4c2674a#4c2674acda8186bacdec430434e9e254d8ff524b"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=871ce54#871ce54a57b21dd9d1765a95f22493affbe98a22"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "4c2674a" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "871ce54"}
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -12,6 +12,9 @@ pub enum ElementCommand {
 
     /// Update an element
     Update(UpdateCommand),
+
+    /// List elements
+    List(ListCommand),
 }
 
 impl Command<ElementCommand> {
@@ -21,6 +24,7 @@ impl Command<ElementCommand> {
         match &self.inner {
             ElementCommand::Create(cmd) => cmd.run(api).await,
             ElementCommand::Update(cmd) => cmd.run(api).await,
+            ElementCommand::List(cmd) => cmd.run(api).await,
         }
     }
 }
@@ -64,6 +68,18 @@ impl UpdateCommand {
 
         let element = api.element(&self.id).update(changeset).await?;
         println!("{:?}", element);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {}
+
+impl ListCommand {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let elements = api.elements().list().await?;
+        println!("{:?}", elements);
 
         Ok(())
     }


### PR DESCRIPTION
**Why**
We would like to be able to fetch all elements via our cli tooling.

**How**
- Add `elements list` cli commands
- Integrate `peridio_sdk::elements::list` api lib call

