### PR TITLE
PRO-240: Add `elements update` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
 ]
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=f133208#f133208b4a4b9f9e350debeb1488668c9459d6af"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=4c2674a#4c2674acda8186bacdec430434e9e254d8ff524b"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "f133208"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "4c2674a" }
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -9,6 +9,9 @@ use structopt::StructOpt;
 pub enum ElementCommand {
     /// Create an element
     Create(CreateCommand),
+
+    /// Update an element
+    Update(UpdateCommand),
 }
 
 impl Command<ElementCommand> {
@@ -17,6 +20,7 @@ impl Command<ElementCommand> {
 
         match &self.inner {
             ElementCommand::Create(cmd) => cmd.run(api).await,
+            ElementCommand::Update(cmd) => cmd.run(api).await,
         }
     }
 }
@@ -35,6 +39,30 @@ impl CreateCommand {
         };
 
         let element = api.elements().create(element).await?;
+        println!("{:?}", element);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct UpdateCommand {
+    /// An element id
+    #[structopt(long)]
+    id: String,
+
+    /// An element name
+    #[structopt(long)]
+    name: String,
+}
+
+impl UpdateCommand {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let changeset = element::ElementChangeset {
+            name: self.name.clone(),
+        };
+
+        let element = api.element(&self.id).update(changeset).await?;
         println!("{:?}", element);
 
         Ok(())


### PR DESCRIPTION
**Why**
We would like to be able to update an element via our cli tooling.

**How**
- Add `elements update --id $id --name $name` cli command.
- Integrate `peridio_sdk::elements::udpate` api lib call.

