### PR TITLE
PRO-241: Add create element version command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=9f27eeb#9f27eeb97a69eb816f3e89cd84e02cf3d1f57d8b"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=1586ca3#1586ca3a11b03466c97780ff5e4a2f6806aad6b4"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "9f27eeb"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "1586ca3"}
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element.rs
+++ b/src/api/element.rs
@@ -1,3 +1,4 @@
+use super::element_version::ElementVersionCommand;
 use super::Command;
 use peridio_sdk::{
     api::{element, Error},
@@ -18,6 +19,9 @@ pub enum ElementCommand {
 
     /// Get an element
     Get(GetCommand),
+
+    /// Operate on versions
+    Versions(ElementVersionCommand),
 }
 
 impl Command<ElementCommand> {
@@ -29,6 +33,7 @@ impl Command<ElementCommand> {
             ElementCommand::Update(cmd) => cmd.run(api).await,
             ElementCommand::List(cmd) => cmd.run(api).await,
             ElementCommand::Get(cmd) => cmd.run(api).await,
+            ElementCommand::Versions(cmd) => cmd.run(api).await,
         }
     }
 }

--- a/src/api/element_version.rs
+++ b/src/api/element_version.rs
@@ -1,0 +1,51 @@
+use peridio_sdk::{
+    api::{element, Error},
+    Api,
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct VersionCommand<T: StructOpt> {
+    #[structopt(long)]
+    pub element_id: String,
+
+    #[structopt(flatten)]
+    inner: T,
+}
+
+#[derive(StructOpt, Debug)]
+pub enum ElementVersionCommand {
+    Create(VersionCommand<CreateCommand>),
+}
+
+impl ElementVersionCommand {
+    pub async fn run(&self, api: Api) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run(api).await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    #[structopt(long)]
+    number: String,
+}
+
+impl VersionCommand<CreateCommand> {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let version = element::ElementVersionChangeset {
+            number: self.inner.number.clone(),
+        };
+
+        let version = api
+            .element(&self.element_id)
+            .versions()
+            .create(version)
+            .await?;
+
+        println!("{:?}", version);
+
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 mod element;
+mod element_version;
 mod identity;
 
 use std::ops::Deref;


### PR DESCRIPTION
**Why**
We would like to be able to create an element version via our cli tooling.

**How**
- Add `elements versions create --element_id $ELEMENT_ID --number $VER_NUMBER` cli command.
- Integrate `peridio_sdk::elements::versions::create` api lib call.

