### PR TITLE
PRO-242: Add get element version command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=1586ca3#1586ca3a11b03466c97780ff5e4a2f6806aad6b4"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=b136d17#b136d177207068c62acb725efc52446871945778"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "1586ca3"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "b136d17"}
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element_version.rs
+++ b/src/api/element_version.rs
@@ -16,12 +16,14 @@ pub struct VersionCommand<T: StructOpt> {
 #[derive(StructOpt, Debug)]
 pub enum ElementVersionCommand {
     Create(VersionCommand<CreateCommand>),
+    Get(VersionCommand<GetCommand>),
 }
 
 impl ElementVersionCommand {
     pub async fn run(&self, api: Api) -> Result<(), Error> {
         match self {
             Self::Create(cmd) => cmd.run(api).await,
+            Self::Get(cmd) => cmd.run(api).await,
         }
     }
 }
@@ -42,6 +44,25 @@ impl VersionCommand<CreateCommand> {
             .element(&self.element_id)
             .versions()
             .create(version)
+            .await?;
+
+        println!("{:?}", version);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    id: String,
+}
+
+impl VersionCommand<GetCommand> {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let version = api
+            .element(&self.element_id)
+            .version(&self.inner.id)
+            .get()
             .await?;
 
         println!("{:?}", version);


### PR DESCRIPTION
**Why**
We would like to be able to fetch an element version via our cli tooling.

**How**
- Add `elements versions --element-id $ELEMENT_ID $version_id` cli command.
- Integrate `peridio_sdk::elements::versions::get` api lib call.

