### PR TITLE
PRO-243: Add list element versions command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=b136d17#b136d177207068c62acb725efc52446871945778"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=a2fc27c#a2fc27ccb25b5b5d307df1eb0fce4a73c874345c"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "b136d17"}
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "a2fc27c"}
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/element_version.rs
+++ b/src/api/element_version.rs
@@ -17,6 +17,7 @@ pub struct VersionCommand<T: StructOpt> {
 pub enum ElementVersionCommand {
     Create(VersionCommand<CreateCommand>),
     Get(VersionCommand<GetCommand>),
+    List(VersionCommand<ListCommand>),
 }
 
 impl ElementVersionCommand {
@@ -24,6 +25,7 @@ impl ElementVersionCommand {
         match self {
             Self::Create(cmd) => cmd.run(api).await,
             Self::Get(cmd) => cmd.run(api).await,
+            Self::List(cmd) => cmd.run(api).await,
         }
     }
 }
@@ -66,6 +68,19 @@ impl VersionCommand<GetCommand> {
             .await?;
 
         println!("{:?}", version);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {}
+
+impl VersionCommand<ListCommand> {
+    async fn run(&self, api: Api) -> Result<(), Error> {
+        let versions = api.element(&self.element_id).versions().list().await?;
+
+        println!("{:?}", versions);
 
         Ok(())
     }


### PR DESCRIPTION
**Why**
We would like to be able to list all element versions via our cli tooling.

**How**
- Add `elements versions list --element_id $ELEMENT_ID` cli command.
- Integrate `peridio_sdk::elements::versions::list` api lib call.

