### PR TITLE
PRO-244: Add binary create command

### DIFF
--- a/src/api/binary.rs
+++ b/src/api/binary.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+use super::Command;
+use crate::{print_json, ApiSnafu, Error, FileSnafu};
+use peridio_sdk::api::Api;
+use snafu::ResultExt;
+use structopt::StructOpt;
+use tokio::fs::File;
+use tokio::io::{self, AsyncRead};
+
+#[derive(StructOpt, Debug)]
+pub enum BinaryCommand {
+    /// Create a binary
+    Create(Command<CreateCommand>),
+}
+
+impl BinaryCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    /// A path to a local binary.
+    /// If no file is provided, reads from standard input
+    #[structopt(long, parse(from_os_str))]
+    pub file: Option<PathBuf>,
+
+    /// An element id
+    #[structopt(long)]
+    pub element_id: String,
+
+    /// A version id
+    #[structopt(long)]
+    pub version_id: String,
+}
+
+impl Command<CreateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+
+        let rdr: Box<dyn AsyncRead + Sync + Send + Unpin> = match &self.inner.file {
+            Some(v) => Box::new(File::open(v).await.context(FileSnafu)?),
+            None => Box::new(io::stdin()),
+        };
+
+        let binary = api
+            .element(&self.inner.element_id)
+            .version(&self.inner.version_id)
+            .binaries()
+            .create(rdr)
+            .await
+            .context(ApiSnafu)?;
+
+        print_json!(&binary);
+
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+mod binary;
 mod element;
 mod identity;
 mod version;

--- a/src/api/version.rs
+++ b/src/api/version.rs
@@ -1,3 +1,4 @@
+use super::binary::BinaryCommand;
 use super::Command;
 use crate::{print_json, ApiSnafu, Error};
 use peridio_sdk::api::{Api, VersionChangeset};
@@ -14,6 +15,9 @@ pub enum VersionCommand {
 
     /// List versions
     List(Command<ListCommand>),
+
+    /// Operate on binaries
+    Binary(BinaryCommand),
 }
 
 impl VersionCommand {
@@ -22,6 +26,7 @@ impl VersionCommand {
             Self::Create(cmd) => cmd.run().await,
             Self::Get(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
+            Self::Binary(cmd) => cmd.run().await,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod agent;
 mod api;
 
-use std::fmt;
+use std::{fmt, io};
 
 use snafu::Snafu;
 use structopt::StructOpt;
@@ -27,6 +27,9 @@ pub enum Error {
 
     #[snafu(display("Unable to serialize to JSON {}", source))]
     JsonSerialization { source: serde_json::Error },
+
+    #[snafu(display("Unable to open file {}", source))]
+    File { source: io::Error },
 }
 
 impl fmt::Debug for Error {


### PR DESCRIPTION
**Why**
We would like to be able to create an element-version-binary via our cli tooling.

**How**
- Add `element version  binary create --element_id $ELEMENT_ID --version-id $VERSION_ID` cli command.
- Integrate `peridio_sdk::elements::versions::binaries::create` api lib call.

