### PR TITLE
PRO-245: Add element-version-binary get command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=1599a98#1599a98fdb79699a1e84216a5a89b2ccbd0b4ca0"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=0a7043f#0a7043f1fe31f4b3d3db8ace892c51ca5de7109e"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "1599a98" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "0a7043f" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"


### PR DESCRIPTION
**Why**
We would like to be able to get an element-version-binary via our cli tooling.

**How**
- Add `element version binary get --element_id $ELEMENT_ID --version-id $VERSION_ID --binary-id $BINARY_ID` cli command.
- Integrate `peridio_sdk::element::version::binary::get` api lib call.

