### PR TITLE
PRO-246: Add list binaries command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=0a7043f#0a7043f1fe31f4b3d3db8ace892c51ca5de7109e"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=ad26dd5#ad26dd54d324a061d6cb064809223c34080d91e4"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "0a7043f" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ad26dd5" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/binary.rs
+++ b/src/api/binary.rs
@@ -15,6 +15,9 @@ pub enum BinaryCommand {
 
     /// Get a binary
     Get(Command<GetCommand>),
+
+    /// List binaries
+    List(Command<ListCommand>),
 }
 
 impl BinaryCommand {
@@ -22,6 +25,7 @@ impl BinaryCommand {
         match self {
             Self::Create(cmd) => cmd.run().await,
             Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
         }
     }
 }
@@ -93,6 +97,35 @@ impl Command<GetCommand> {
             .context(ApiSnafu)?;
 
         print_json!(&binary);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {
+    /// An element id
+    #[structopt(long)]
+    pub element_id: String,
+
+    /// A version id
+    #[structopt(long)]
+    pub version_id: String,
+}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+
+        let binaries = api
+            .element(&self.inner.element_id)
+            .version(&self.inner.version_id)
+            .binaries()
+            .list()
+            .await
+            .context(ApiSnafu)?;
+
+        print_json!(&binaries);
 
         Ok(())
     }


### PR DESCRIPTION
**Why**
We would like to be able to list all binaries via our cli tooling.

**How**
- Add `element version binary list --element_id $ELEMENT_ID --version-id $VERSION_ID` cli command.
- Integrate `peridio_sdk::element::version::binaries::list` api lib call.

