### PR TITLE
PRO-329: Add node-type create cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=ad26dd5#ad26dd54d324a061d6cb064809223c34080d91e4"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=45713d6#45713d655effcedc85c4d9f12bb0206075049637"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ad26dd5" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "45713d6" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,7 @@
 mod binary;
 mod element;
 mod identity;
+mod node_type;
 mod version;
 
 use structopt::StructOpt;
@@ -24,6 +25,9 @@ pub enum ApiCommand {
 
     /// Operate on elements
     Element(element::ElementCommand),
+
+    /// Operate on node-types
+    NodeType(node_type::NodeTypeCommand),
 }
 
 impl ApiCommand {
@@ -31,6 +35,7 @@ impl ApiCommand {
         match self {
             ApiCommand::Identity(cmd) => identity::run(cmd).await?,
             ApiCommand::Element(cmd) => cmd.run().await?,
+            ApiCommand::NodeType(cmd) => cmd.run().await?,
         };
 
         Ok(())

--- a/src/api/node_type.rs
+++ b/src/api/node_type.rs
@@ -1,0 +1,41 @@
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::{Api, NodeTypeChangeset};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum NodeTypeCommand {
+    /// Create a node-type
+    Create(Command<CreateCommand>),
+}
+
+impl NodeTypeCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    /// A node-type name
+    #[structopt(long)]
+    name: String,
+}
+
+impl Command<CreateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+        let node_type = NodeTypeChangeset {
+            name: self.inner.name,
+        };
+
+        let node_type = api.node_types().create(node_type).await.context(ApiSnafu)?;
+
+        print_json!(&node_type);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
**Why**
We would like to create node-types via our cli tooling.

**How**
- Add `node-type create --name $NAME` cli command.

