### PR TITLE
PRO-331: add node-type list cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=45713d6#45713d655effcedc85c4d9f12bb0206075049637"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=9dcf076#9dcf0763ded8f97b3ddd94b012fcfe114303326e"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "45713d6" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "9dcf076" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/node_type.rs
+++ b/src/api/node_type.rs
@@ -8,12 +8,16 @@ use structopt::StructOpt;
 pub enum NodeTypeCommand {
     /// Create a node-type
     Create(Command<CreateCommand>),
+
+    /// List node-types
+    List(Command<ListCommand>),
 }
 
 impl NodeTypeCommand {
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Self::Create(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
         }
     }
 }
@@ -35,6 +39,20 @@ impl Command<CreateCommand> {
         let node_type = api.node_types().create(node_type).await.context(ApiSnafu)?;
 
         print_json!(&node_type);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+        let node_types = api.node_types().list().await.context(ApiSnafu)?;
+
+        print_json!(&node_types);
 
         Ok(())
     }


### PR DESCRIPTION
**Why**
We would like to list all node-types via our cli tooling.

**How**
- Add `node-type list` cli command.

