### PR TITLE
PRO-332: Add node-type update cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=ef439d3#ef439d3d9aeb1c479c3af0df858cc1d2b69879e0"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=ae0d987#ae0d987e0c0936ab5dfec7d4fb8db71f25242e2a"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ef439d3" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ae0d987" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/node_type.rs
+++ b/src/api/node_type.rs
@@ -12,6 +12,9 @@ pub enum NodeTypeCommand {
     /// Get a node-type
     Get(Command<GetCommand>),
 
+    /// Update a node-type
+    Update(Command<UpdateCommand>),
+
     /// List node-types
     List(Command<ListCommand>),
 }
@@ -21,6 +24,7 @@ impl NodeTypeCommand {
         match self {
             Self::Create(cmd) => cmd.run().await,
             Self::Get(cmd) => cmd.run().await,
+            Self::Update(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
         }
     }
@@ -61,6 +65,36 @@ impl Command<GetCommand> {
         let node_type = api
             .node_type(&self.inner.id)
             .get()
+            .await
+            .context(ApiSnafu)?;
+
+        print_json!(&node_type);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct UpdateCommand {
+    /// An element id
+    #[structopt(long)]
+    id: String,
+
+    /// An element name
+    #[structopt(long)]
+    name: String,
+}
+
+impl Command<UpdateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+        let changeset = NodeTypeChangeset {
+            name: self.inner.name,
+        };
+
+        let node_type = api
+            .node_type(&self.inner.id)
+            .update(changeset)
             .await
             .context(ApiSnafu)?;
 


### PR DESCRIPTION
**Why**
We would like update node-type via our cli tooling.

**How**
- Add `node-type update --id $ID --name $NAME` cli command.

