### PR TITLE
PRO-330: Add node-type get cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=9dcf076#9dcf0763ded8f97b3ddd94b012fcfe114303326e"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=ef439d3#ef439d3d9aeb1c479c3af0df858cc1d2b69879e0"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "9dcf076" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ef439d3" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/node_type.rs
+++ b/src/api/node_type.rs
@@ -9,6 +9,9 @@ pub enum NodeTypeCommand {
     /// Create a node-type
     Create(Command<CreateCommand>),
 
+    /// Get a node-type
+    Get(Command<GetCommand>),
+
     /// List node-types
     List(Command<ListCommand>),
 }
@@ -17,6 +20,7 @@ impl NodeTypeCommand {
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Self::Create(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
         }
     }
@@ -37,6 +41,28 @@ impl Command<CreateCommand> {
         };
 
         let node_type = api.node_types().create(node_type).await.context(ApiSnafu)?;
+
+        print_json!(&node_type);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    /// A node-type id
+    #[structopt(long)]
+    id: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+        let node_type = api
+            .node_type(&self.inner.id)
+            .get()
+            .await
+            .context(ApiSnafu)?;
 
         print_json!(&node_type);
 


### PR DESCRIPTION
**Why**
We would like to fetch a node-type by id via our cli tooling.

**How**
- Add `node-type get --id $ID` cli command.

