### PR TITLE
PRO-341: Add distribution create cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=ae0d987#ae0d987e0c0936ab5dfec7d4fb8db71f25242e2a"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=c48549b#c48549b3822d6704b98d7474aba0e2e2bdc7d66a"
 dependencies = [
  "chrono",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ae0d987" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "c48549b" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/distribution.rs
+++ b/src/api/distribution.rs
@@ -1,0 +1,60 @@
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::{Api, DistributionChangeset};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum DistributionCommand {
+    /// Create a distribution
+    Create(Command<CreateCommand>),
+}
+
+impl DistributionCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    /// A distribution name
+    #[structopt(long)]
+    name: String,
+
+    /// The associated element version id
+    #[structopt(long)]
+    element_version_id: String,
+
+    /// A parent distribution id
+    #[structopt(long)]
+    next_distribution_id: Option<String>,
+
+    /// A node group id
+    #[structopt(long)]
+    node_group_id: Option<String>,
+}
+
+impl Command<CreateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+        let distribution = DistributionChangeset {
+            name: self.inner.name,
+            element_version_id: self.inner.element_version_id,
+            next_distribution_id: self.inner.next_distribution_id,
+            node_group_id: self.inner.node_group_id,
+        };
+
+        let distribution = api
+            .distributions()
+            .create(distribution)
+            .await
+            .context(ApiSnafu)?;
+
+        print_json!(&distribution);
+
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 mod binary;
+mod distribution;
 mod element;
 mod identity;
 mod node_type;
@@ -28,6 +29,9 @@ pub enum ApiCommand {
 
     /// Operate on node-types
     NodeType(node_type::NodeTypeCommand),
+
+    /// Operate on distributions
+    Distribution(distribution::DistributionCommand),
 }
 
 impl ApiCommand {
@@ -36,6 +40,7 @@ impl ApiCommand {
             ApiCommand::Identity(cmd) => identity::run(cmd).await?,
             ApiCommand::Element(cmd) => cmd.run().await?,
             ApiCommand::NodeType(cmd) => cmd.run().await?,
+            ApiCommand::Distribution(cmd) => cmd.run().await?,
         };
 
         Ok(())


### PR DESCRIPTION
**Why**
We would like to create a distribution by id via our cli tooling.

**How**
- Add `distribution create ...` cli command.

