### PR TITLE
PRO-340: Add distribution get cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=371f761#371f761b21da93d59f272e6a55b56c6abb8a3e2e"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=cc91f86#cc91f861e4a05904a47b190942866ab075ab83fb"
 dependencies = [
  "async-stream",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "371f761" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "cc91f86" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/distribution.rs
+++ b/src/api/distribution.rs
@@ -9,6 +9,9 @@ pub enum DistributionCommand {
     /// Create a distribution
     Create(Command<CreateCommand>),
 
+    /// Get a distribution
+    Get(Command<GetCommand>),
+
     /// List distributions
     List(Command<ListCommand>),
 }
@@ -17,6 +20,7 @@ impl DistributionCommand {
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Self::Create(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
         }
     }
@@ -54,6 +58,28 @@ impl Command<CreateCommand> {
         let distribution = api
             .distributions()
             .create(distribution)
+            .await
+            .context(ApiSnafu)?;
+
+        print_json!(&distribution);
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    /// A distribution id
+    #[structopt(long)]
+    id: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let api = Api::new(self.api_key, self.base_url);
+        let distribution = api
+            .distribution(&self.inner.id)
+            .get()
             .await
             .context(ApiSnafu)?;
 


### PR DESCRIPTION
**Why**
We would like to create get a distribution by id via our cli tooling.

**How**
- Add `distribution get ...` cli command.

