### PR TITLE
PRO-338: Make name optional for distribution update cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=ca826e7#ca826e738c23c88653a15e3838cee24f4dcf4fd2"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=3c57a04#3c57a0486767423513077d54ff3364625c6559a4"
 dependencies = [
  "async-stream",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ca826e7" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "3c57a04" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/distribution.rs
+++ b/src/api/distribution.rs
@@ -53,8 +53,8 @@ impl Command<CreateCommand> {
     async fn run(self) -> Result<(), Error> {
         let api = Api::new(self.api_key, self.base_url);
         let distribution = DistributionChangeset {
-            name: self.inner.name,
-            element_version_id: self.inner.element_version_id,
+            name: Some(self.inner.name),
+            element_version_id: Some(self.inner.element_version_id),
             next_distribution_id: self.inner.next_distribution_id,
             node_group_id: self.inner.node_group_id,
         };
@@ -101,7 +101,7 @@ pub struct UpdateCommand {
 
     /// A distribution name
     #[structopt(long)]
-    name: String,
+    name: Option<String>,
 
     /// A parent distribution id
     #[structopt(long)]


### PR DESCRIPTION
**Why**
We would like to ensure `distribution update` command meets spec.

**How**
- Make option `--name` optional in `distribution update`.

