### PR TITLE
PRO-359: Validate binary file size is greater than 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,28 +263,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -292,34 +276,6 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -339,16 +295,10 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -743,12 +693,9 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=233fb33#233fb337dacb21d3906e32c7bec1b98528db9eac"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=508e8ce#508e8ce2240b194762a00e8d3e59d40898da6872"
 dependencies = [
- "async-stream",
- "bytes",
  "chrono",
- "futures",
  "prost",
  "prost-build",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "233fb33" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "508e8ce" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod agent;
 mod api;
 
-use std::{fmt, io};
+use std::{fmt, io, path};
 
 use snafu::Snafu;
 use structopt::StructOpt;
@@ -30,6 +30,12 @@ pub enum Error {
 
     #[snafu(display("Unable to open file {}", source))]
     File { source: io::Error },
+
+    #[snafu(display("File {:?} is empty", path))]
+    EmptyFile { path: path::PathBuf },
+
+    #[snafu(display("Unable to retrieve file metadata {:?}", source))]
+    FileMetadata { source: io::Error },
 }
 
 impl fmt::Debug for Error {


### PR DESCRIPTION
**Why**
We would like to validate the file contents provided by the user. The provided binary should be greater than 0 in byte size. The standard input stream is not validated in order to align with Linux-isms.

**How**
- Add validator for File.

