### PR TITLE
PRO-321: account for dev release in the CLI "version" command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+
+fn main() {
+    // This is ran only during build process, we expect to always have git when building the app
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!(
+        "cargo:rustc-env=MOREL_VERSION={}-{}",
+        env!("CARGO_PKG_VERSION"),
+        git_hash
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ impl fmt::Debug for Error {
 }
 
 #[derive(StructOpt)]
+#[structopt(version = env!("MOREL_VERSION"))]
 struct Program {
     #[structopt(subcommand)]
     command: Command,


### PR DESCRIPTION
Why:

We want to include the git hash to the `--version` command.

How:

- add `build.rs` introducing the MOREL_VERSION variable 