### PR TITLE
Don't require --organization-name for users me subcommand

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -38,6 +38,8 @@ where
 pub enum CliCommands {
     #[command(flatten)]
     ApiCommand(ApiCommand),
+    #[command(subcommand)]
+    Users(users::UsersCommand),
     #[command()]
     Upgrade(upgrade::UpgradeCommand),
     #[command(subcommand)]
@@ -80,8 +82,6 @@ pub enum ApiCommand {
     Releases(releases::ReleasesCommand),
     #[command(subcommand)]
     SigningKeys(signing_keys::SigningKeysCommand),
-    #[command(subcommand)]
-    Users(users::UsersCommand),
     #[command(subcommand)]
     Webhooks(webhooks::WebhooksCommand),
 }
@@ -134,10 +134,10 @@ impl CliCommands {
                     ApiCommand::ProductsV2(cmd) => cmd.run(global_options).await?,
                     ApiCommand::Releases(cmd) => cmd.run(global_options).await?,
                     ApiCommand::SigningKeys(cmd) => cmd.run(global_options).await?,
-                    ApiCommand::Users(cmd) => cmd.run(global_options).await?,
                     ApiCommand::Webhooks(cmd) => cmd.run(global_options).await?,
                 }
             }
+            CliCommands::Users(cmd) => cmd.run(global_options).await?,
             CliCommands::Upgrade(cmd) => cmd.run().await?,
             CliCommands::Config(cmd) => cmd.run(global_options).await?,
         };

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -91,30 +91,18 @@ impl CliCommands {
         match self {
             CliCommands::ApiCommand(api) => {
                 // require api key
-                let mut error_vec = Vec::new();
+                let mut missing_arguments = Vec::new();
 
                 if global_options.api_key.is_none() {
-                    error_vec.push("--api-key".to_owned());
+                    missing_arguments.push("--api-key".to_owned());
                 }
 
                 // require organization name
                 if global_options.organization_name.is_none() {
-                    error_vec.push("--organization-name".to_owned());
+                    missing_arguments.push("--organization-name".to_owned());
                 }
 
-                if !error_vec.is_empty() {
-                    let mut error = StyledStr::new();
-
-                    error.push_str(Some(Style::Error), "error: ".to_string());
-                    error.push_str(
-                        None,
-                        "The following arguments are required at the global level:\r\n".to_string(),
-                    );
-                    for error_msg in error_vec.iter() {
-                        error.push_str(Some(Style::Success), format!("\t{error_msg}\r\n"));
-                    }
-                    error.print_data_err();
-                }
+                Self::print_missing_arguments(missing_arguments);
 
                 match api {
                     ApiCommand::Artifacts(cmd) => cmd.run(global_options).await?,
@@ -143,5 +131,21 @@ impl CliCommands {
         };
 
         Ok(())
+    }
+
+    pub(crate) fn print_missing_arguments(missing_arguments: Vec<String>) {
+        if !missing_arguments.is_empty() {
+            let mut error = StyledStr::new();
+
+            error.push_str(Some(Style::Error), "error: ".to_string());
+            error.push_str(
+                None,
+                "The following arguments are required:\r\n".to_string(),
+            );
+            for missing_argument in missing_arguments.iter() {
+                error.push_str(Some(Style::Success), format!("\t{missing_argument}\r\n"));
+            }
+            error.print_data_err();
+        }
     }
 }

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -1,6 +1,6 @@
 use super::Command;
+use crate::api::CliCommands;
 use crate::print_json;
-use crate::utils::{Style, StyledStr};
 use crate::ApiSnafu;
 use crate::Error;
 use crate::GlobalOptions;
@@ -28,25 +28,13 @@ pub struct MeCommand {}
 impl Command<MeCommand> {
     async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         // require api key
-        let mut error_vec = Vec::new();
+        let mut missing_arguments = Vec::new();
 
         if global_options.api_key.is_none() {
-            error_vec.push("--api-key".to_owned());
+            missing_arguments.push("--api-key".to_owned());
         }
 
-        if !error_vec.is_empty() {
-            let mut error = StyledStr::new();
-
-            error.push_str(Some(Style::Error), "error: ".to_string());
-            error.push_str(
-                None,
-                "The following arguments are required at the global level:\r\n".to_string(),
-            );
-            for error_msg in error_vec.iter() {
-                error.push_str(Some(Style::Success), format!("\t{error_msg}\r\n"));
-            }
-            error.print_data_err();
-        }
+        CliCommands::print_missing_arguments(missing_arguments);
 
         let api = Api::new(ApiOptions {
             api_key: global_options.api_key.unwrap(),

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -1,5 +1,6 @@
 use super::Command;
 use crate::print_json;
+use crate::utils::{Style, StyledStr};
 use crate::ApiSnafu;
 use crate::Error;
 use crate::GlobalOptions;
@@ -26,6 +27,27 @@ pub struct MeCommand {}
 
 impl Command<MeCommand> {
     async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+        // require api key
+        let mut error_vec = Vec::new();
+
+        if global_options.api_key.is_none() {
+            error_vec.push("--api-key".to_owned());
+        }
+
+        if !error_vec.is_empty() {
+            let mut error = StyledStr::new();
+
+            error.push_str(Some(Style::Error), "error: ".to_string());
+            error.push_str(
+                None,
+                "The following arguments are required at the global level:\r\n".to_string(),
+            );
+            for error_msg in error_vec.iter() {
+                error.push_str(Some(Style::Success), format!("\t{error_msg}\r\n"));
+            }
+            error.print_data_err();
+        }
+
         let api = Api::new(ApiOptions {
             api_key: global_options.api_key.unwrap(),
             endpoint: global_options.base_url,


### PR DESCRIPTION
# Reproduction Steps

- [ ] `git checkout main`
- [ ] `cargo build --release`
- [ ] Ensure no config is setup for the CLI.
- [ ] Run `users me` against the production API without `--organization-name` option: `./target/release/peridio-cli --api-key=<PRODUCTION_API_KEY> users me`
- [ ] **VERIFY** error is printed
    ```
    error: The following arguments are required at the global level:

      --organization-name
    ```

# Test Plan

- [ ] `git checkout ENG-1330`
- [ ] `cargo build release`
- [ ] Ensure no config is setup for the CLI.
- [ ] Run users me against the production API without `--organization-name` option: `./target/release/peridio-cli --api-key=<PRODUCTION_API_KEY> users me`
- [ ] VERIFY User JSON is printed: `{"data":{"email":<EMAIL>,"username":<USERNAME>}}`