### PR TITLE
v0.22.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# peridio-cli
+
+## v0.22.2
+
+* Bug fixes
+  * Add support for optionally passing `--jitp-target` to `ca-certificates` `create` and `update`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "peridio-cli"
 description = "Peridio CLI"
 homepage = "https://peridio.com"
 repository = "https://github.com/peridio/peridio-cli"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
* Bug fixes
  * Add support for optionally passing `--jitp-target` to `ca-certificates` `create` and `update`
