### PR TITLE
add x509 command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +188,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -380,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +439,29 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -425,6 +499,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -930,6 +1015,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,10 +1041,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -987,6 +1113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1050,6 +1185,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1215,7 @@ version = "0.23.0"
 dependencies = [
  "assert_cmd",
  "backon",
- "base64",
+ "base64 0.21.7",
  "clap",
  "clap-num",
  "console",
@@ -1082,6 +1227,7 @@ dependencies = [
  "indicatif",
  "peridio-sdk",
  "predicates",
+ "rcgen",
  "reqwest",
  "serde",
  "serde_json",
@@ -1091,9 +1237,11 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
+ "time",
  "tokio",
  "tower",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1165,6 +1313,12 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1275,6 +1429,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1515,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1416,6 +1584,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,8 +1623,14 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -1712,6 +1895,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1982,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.65",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2352,6 +2577,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2603,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ sha2 = "0.10.7"
 backon = "0.4.1"
 console = "0.15.7"
 clap-num = "1.1.1"
+rcgen = { version = "0.13.1", features = ["pem", "x509-parser"] }
+time = { version = "0.3.30", features = ["formatting", "parsing", "macros"] }
+x509-parser = "0.16.0"
 
 [dev-dependencies]
 # assert on peridio-cli for integration tests

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,7 @@ mod tunnels;
 mod upgrade;
 mod users;
 mod webhooks;
+mod x509;
 use crate::utils::Style;
 use crate::utils::StyledStr;
 use crate::GlobalOptions;
@@ -39,12 +40,18 @@ where
 pub enum CliCommands {
     #[command(flatten)]
     ApiCommand(ApiCommand),
+    /// Inspect the calling users's identity
     #[command(subcommand)]
     Users(users::UsersCommand),
+    /// Upgrade the CLI
     #[command()]
     Upgrade(upgrade::UpgradeCommand),
+    /// Manage the CLI's config
     #[command(subcommand)]
     Config(config::ConfigCommand),
+    /// Create X.509 certificates and private keys
+    #[command(subcommand)]
+    X509(x509::X509Command),
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -132,6 +139,7 @@ impl CliCommands {
             CliCommands::Users(cmd) => cmd.run(global_options).await?,
             CliCommands::Upgrade(cmd) => cmd.run().await?,
             CliCommands::Config(cmd) => cmd.run(global_options).await?,
+            CliCommands::X509(cmd) => cmd.run(global_options).await?,
         };
 
         Ok(())

--- a/src/api/x509.rs
+++ b/src/api/x509.rs
@@ -1,0 +1,214 @@
+use super::Command;
+use crate::print_json;
+use crate::utils::{Style, StyledStr};
+use crate::{
+    CertParamsCreationSnafu, CertificateCreationSnafu, Error, GlobalOptions, NonExistingPathSnafu,
+};
+use ::time::macros::format_description;
+use ::time::OffsetDateTime;
+use clap::Parser;
+use rcgen::{CertificateParams, DistinguishedName, DnType, IsCa, KeyPair};
+use serde_json::json;
+use snafu::ResultExt;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Debug)]
+pub struct CreateCommand {
+    /// The Common Name (CN) for the certificate
+    #[arg(long)]
+    common_name: String,
+
+    /// Whether this certificate is a Certificate Authority (CA)
+    #[arg(long, default_value = "false")]
+    is_ca: bool,
+
+    /// The start date of the certificate's validity period (format: YYYY-MM-DD)
+    #[arg(long)]
+    start_date: String,
+
+    /// The end date of the certificate's validity period (format: YYYY-MM-DD)
+    #[arg(long)]
+    end_date: String,
+
+    /// Path to the private key file of the signer (required if signer_cert is provided)
+    #[arg(long, requires = "signer_cert", conflicts_with = "signer")]
+    signer_key: Option<PathBuf>,
+
+    /// Path to the certificate file of the signer (required if signer_key is provided)
+    #[arg(long, requires = "signer_key", conflicts_with = "signer")]
+    signer_cert: Option<PathBuf>,
+
+    /// Directory to save the created certificate and private key to (defaults to current working directory)
+    #[arg(long)]
+    out: Option<PathBuf>,
+
+    /// The name of a certificate authority in your Peridio CLI config.
+    #[arg(long, conflicts_with_all = ["signer_key", "signer_cert"])]
+    signer: Option<String>,
+}
+
+#[derive(Parser, Debug)]
+pub enum X509Command {
+    Create(Command<CreateCommand>),
+}
+
+impl X509Command {
+    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run(global_options).await,
+        }
+    }
+}
+
+impl Command<CreateCommand> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+        let mut params = CertificateParams::default();
+
+        // is ca
+        params.is_ca = if self.inner.is_ca {
+            IsCa::Ca(rcgen::BasicConstraints::Unconstrained)
+        } else {
+            IsCa::ExplicitNoCa
+        };
+
+        // authority key identifier
+        params.use_authority_key_identifier_extension = true;
+
+        // distinguished name
+        let mut distinguished_name = DistinguishedName::new();
+        distinguished_name.push(DnType::CommonName, self.inner.common_name.clone());
+        params.distinguished_name = distinguished_name;
+
+        // validity period
+        let start = parse_date(&self.inner.start_date)?;
+        let end = parse_date(&self.inner.end_date)?;
+        params.not_before = start;
+        params.not_after = end;
+
+        // key pair
+        let key_pair = KeyPair::generate().context(CertParamsCreationSnafu)?;
+
+        // signed by or self signed
+        let cert = if let Some(signer_name) = self.inner.signer {
+            if let Some(signer) = global_options
+                .certificate_authorities
+                .unwrap()
+                .get(&signer_name)
+            {
+                let signer_key = {
+                    let path = Path::new(&signer.private_key);
+                    if !path.exists() {
+                        return Err(Error::NonExistingPath {
+                            path: path.to_path_buf(),
+                            source: std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "File not found",
+                            ),
+                        });
+                    }
+                    KeyPair::from_pem(
+                        &fs::read_to_string(path).context(NonExistingPathSnafu { path })?,
+                    )
+                    .context(CertParamsCreationSnafu)?
+                };
+
+                let signer_cert_pem = {
+                    let path = Path::new(&signer.certificate);
+                    if !path.exists() {
+                        return Err(Error::NonExistingPath {
+                            path: path.to_path_buf(),
+                            source: std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "File not found",
+                            ),
+                        });
+                    }
+                    fs::read_to_string(path).context(NonExistingPathSnafu { path })?
+                };
+
+                let signer_cert = CertificateParams::from_ca_cert_pem(&signer_cert_pem)
+                    .context(CertParamsCreationSnafu)?
+                    .self_signed(&signer_key)
+                    .context(CertificateCreationSnafu)?;
+                params
+                    .signed_by(&key_pair, &signer_cert, &signer_key)
+                    .context(CertificateCreationSnafu)?
+            } else {
+                let mut error = StyledStr::new();
+                error.push_str(Some(Style::Error), "error: ".to_string());
+                error.push_str(None, "Certificate Authority ".to_string());
+                error.push_str(None, "'".to_string());
+                error.push_str(Some(Style::Warning), signer_name.to_string());
+                error.push_str(None, "'".to_string());
+                error.push_str(None, " not found.".to_string());
+                error.print_data_err();
+            }
+        } else if let (Some(signer_key_path), Some(signer_cert_path)) =
+            (self.inner.signer_key, self.inner.signer_cert)
+        {
+            let signer_key = {
+                let path = Path::new(&signer_key_path);
+                if !path.exists() {
+                    return Err(Error::NonExistingPath {
+                        path: path.to_path_buf(),
+                        source: std::io::Error::new(std::io::ErrorKind::NotFound, "File not found"),
+                    });
+                }
+                KeyPair::from_pem(&fs::read_to_string(path).context(NonExistingPathSnafu { path })?)
+                    .context(CertParamsCreationSnafu)?
+            };
+
+            let signer_cert_pem = {
+                let path = Path::new(&signer_cert_path);
+                if !path.exists() {
+                    return Err(Error::NonExistingPath {
+                        path: path.to_path_buf(),
+                        source: std::io::Error::new(std::io::ErrorKind::NotFound, "File not found"),
+                    });
+                }
+                fs::read_to_string(path).context(NonExistingPathSnafu { path })?
+            };
+
+            let signer_cert = CertificateParams::from_ca_cert_pem(&signer_cert_pem)
+                .context(CertParamsCreationSnafu)?
+                .self_signed(&signer_key)
+                .context(CertificateCreationSnafu)?;
+            params
+                .signed_by(&key_pair, &signer_cert, &signer_key)
+                .context(CertificateCreationSnafu)?
+        } else {
+            params
+                .self_signed(&key_pair)
+                .context(CertificateCreationSnafu)?
+        };
+
+        let cert_pem = cert.pem();
+        let key_pem = key_pair.serialize_pem();
+
+        let out_dir = self
+            .inner
+            .out
+            .unwrap_or_else(|| env::current_dir().unwrap());
+        fs::create_dir_all(&out_dir).unwrap();
+        let cert_filename = format!("{}-certificate.pem", self.inner.common_name);
+        let key_filename = format!("{}-private-key.pem", self.inner.common_name);
+        fs::write(out_dir.join(cert_filename.clone()), &cert_pem).unwrap();
+        fs::write(out_dir.join(key_filename.clone()), &key_pem).unwrap();
+
+        print_json!(&json!({
+            "certificate": out_dir.join(cert_filename),
+            "private_key": out_dir.join(key_filename)
+        }));
+
+        Ok(())
+    }
+}
+
+fn parse_date(date_str: &str) -> Result<OffsetDateTime, Error> {
+    let format = format_description!("[year]-[month]-[day]");
+    time::Date::parse(date_str, &format)
+        .map(|date| date.with_time(time::Time::MIDNIGHT).assume_utc())
+        .map_err(|e| Error::DateParse { source: e })
+}

--- a/src/config/config_v2.rs
+++ b/src/config/config_v2.rs
@@ -96,11 +96,29 @@ impl Deref for SigningKeyPairsV2 {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CertificateAuthorityV2 {
+    pub private_key: String,
+    pub certificate: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
+pub struct CertificateAuthoritiesV2(HashMap<String, CertificateAuthorityV2>);
+
+impl Deref for CertificateAuthoritiesV2 {
+    type Target = HashMap<String, CertificateAuthorityV2>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ConfigV2 {
     pub version: u8,
     pub profiles: ProfilesV2,
     pub signing_key_pairs: SigningKeyPairsV2,
+    pub certificate_authorities: CertificateAuthoritiesV2,
 }
 
 impl Default for ConfigV2 {
@@ -109,6 +127,7 @@ impl Default for ConfigV2 {
             version: 2,
             profiles: ProfilesV2::default(),
             signing_key_pairs: SigningKeyPairsV2::default(),
+            certificate_authorities: CertificateAuthoritiesV2::default(),
         }
     }
 }
@@ -123,6 +142,7 @@ impl TryFrom<ConfigV1> for ConfigV2 {
                     version: 1,
                     profiles: profiles_v2,
                     signing_key_pairs: SigningKeyPairsV2::default(),
+                    certificate_authorities: CertificateAuthoritiesV2::default(),
                 };
                 Ok(config_v2)
             }


### PR DESCRIPTION
- Add deps: rcgen, time, and x509-parser.
- Add x509 create command.
  - Allows creation of root CA, intermediate CA, and end entity certificates.
  - Validity periods, common names, CA status, out dir, and issuer are configurable.
- Add config support for `certificate_authorities` section that can be referenced as part of the x509 create command a kin to how signing key pairs are referenced when creating signed binaries.