### PR TITLE
improve cert compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
 dependencies = [
  "jobserver",
  "libc",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",

--- a/src/api/x509.rs
+++ b/src/api/x509.rs
@@ -70,7 +70,7 @@ impl Command<CreateCommand> {
         params.is_ca = if self.inner.is_ca {
             IsCa::Ca(rcgen::BasicConstraints::Unconstrained)
         } else {
-            IsCa::ExplicitNoCa
+            IsCa::NoCa
         };
 
         // authority key identifier
@@ -80,6 +80,12 @@ impl Command<CreateCommand> {
         let mut distinguished_name = DistinguishedName::new();
         distinguished_name.push(DnType::CommonName, self.inner.common_name.clone());
         params.distinguished_name = distinguished_name;
+
+        //  key usages
+        params.key_usages = vec![rcgen::KeyUsagePurpose::DigitalSignature];
+
+        // extended key usages
+        params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth];
 
         // validity period
         let start = parse_date(&self.inner.start_date)?;


### PR DESCRIPTION
- x509: improve cert compatibility
  - Use an implicit instead of explicit CA:FALSE to avoid potential
    encoding issues in collaborating software when validating signatures.
  - Add key usage and extended key usage extensions.
- bump deps