### PR TITLE
update `binaries create` arg descriptions

### DIFF
--- a/src/api/binaries.rs
+++ b/src/api/binaries.rs
@@ -199,6 +199,10 @@ pub struct CreateCommand {
     skip_upload: bool,
 
     /// The PRN of the bundle override to associate with this binary.
+    ///
+    /// A bundle will be created for the newly-created binary.
+    ///
+    /// The given bundle override will be updated to this bundle.
     #[arg(
         long,
         value_parser = PRNValueParser::new(PRNType::BundleOverride),
@@ -206,7 +210,13 @@ pub struct CreateCommand {
     )]
     bundle_override_prn: Option<String>,
 
-    /// The PRN of the device to associate with this binary.
+    /// The PRN of the device to stage this binary for.
+    ///
+    /// A bundle will be created for the newly-created binary.
+    ///
+    /// A bundle override will be created with this bundle.
+    ///
+    /// The given device will be added to the bundle override.
     #[arg(
         long,
         value_parser = PRNValueParser::new(PRNType::Device),
@@ -214,7 +224,13 @@ pub struct CreateCommand {
     )]
     device_prn: Option<String>,
 
-    /// The PRN of the cohort to associate with this binary.
+    /// The PRN of a cohort, in which to create a release for.
+    ///
+    /// A bundle will be created for the newly-created binary.
+    ///
+    /// A release will be created for the given cohort with this bundle.
+    ///
+    /// The created release is not required, has scheduled availability of "now", and 100% availability.
     #[arg(
         long,
         value_parser = PRNValueParser::new(PRNType::Cohort),


### PR DESCRIPTION
Tried to be descriptive and clear, but brief.

```
peridio --profile demo binaries create --help

...


      --bundle-override-prn <BUNDLE_OVERRIDE_PRN>
          The PRN of the bundle override to associate with this binary.
          
          A bundle will be created for the newly-created binary.
          
          The given bundle override will be updated to this bundle.

      --device-prn <DEVICE_PRN>
          The PRN of the device to stage this binary for.
          
          A bundle will be created for the newly-created binary.
          
          A bundle override will be created with this bundle.
          
          The given device will be added to the bundle override.

      --cohort-prn <COHORT_PRN>
          The PRN of a cohort, in which to create a release for.
          
          A bundle will be created for the newly-created binary.
          
          A release will be created for the given cohort with this bundle.
          
          The created release is not required, has scheduled availability of "now", and 100% availability.

  -h, --help
          Print help (see a summary with '-h')
```