### PR TITLE
fix `bundle-overrides devices remove` panic on successful 204 response

### DIFF
--- a/src/api/bundle_overrides.rs
+++ b/src/api/bundle_overrides.rs
@@ -366,14 +366,13 @@ impl Command<RemoveDeviceCommand> {
 
         let api = Api::from(global_options);
 
-        match api
+        if let Some(response) = api
             .bundle_overrides()
             .remove_device(params)
             .await
             .context(ApiSnafu)?
         {
-            Some(response) => print_json!(&response),
-            None => panic!(),
+            print_json!(&response)
         }
 
         Ok(())


### PR DESCRIPTION
`RemoveDeviceCommand::run` panicked when the API returned HTTP 204 No Content (the expected response for a successful delete). Changed the `None` arm from `panic!()` to a no-op, matching how `DeleteCommand` already handles this.